### PR TITLE
Change return type of DeepResearchService

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ var ChatClient = new AzureOpenAIClient(
     new DefaultAzureCredential()
 ).GetChatClient("o4-mini");
 
+void OnProgressChanged(ProgressBase progress)
+{
+  // Handle progress updates here
+}
+
 var options = new DeepResearchOptions
 {
     MaxResearchLoops = 3, // Maximum number of loops
@@ -87,10 +92,78 @@ var result = await service.RunResearchAsync(researchTopic, CancellationToken.Non
 Console.WriteLine("\n" + new string('=', 50));
 Console.WriteLine("📋 Research Results");
 Console.WriteLine(new string('=', 50));
-Console.WriteLine(result.RunningSummary);
+Console.WriteLine(result.Summary);
 
 Console.WriteLine("\nPress any key to exit...");
 Console.ReadKey();
+```
+
+## Return Values and Progress Notifications
+
+DeepResearchService returns a ResearchResult object when the research is completed.
+This object contains the research summary and related information.
+
+- ResearchTopic: The topic of the research
+- Summary: The final research report
+- Sources: List of information collected during the research
+- Images: List of images collected during the research
+
+Additionally, by specifying the onProgressChanged callback in the DeepResearchService constructor arguments, you can receive real-time notifications of the research status.
+Progressive notifications are defined as classes for each step that inherit from ProgressBase.
+
+- QueryGenerationProgress: Notification class for query generation completion
+- WebResearchProgress: Notification class for web search completion
+- SummarizeProgress: Notification class for search result summarization completion
+- ReflectionProgress: Notification class for knowledge gap analysis completion
+- RoutingProgress: Notification class for next process determination completion
+- FinalizeProgress: Notification class for research report creation start
+- ResearchCompleteProgress: Notification class for research report creation completion
+- ErrorProgress: Notification class for errors that occur during research
+
+For example, you can receive and handle notification classes as follows:
+
+```csharp
+void OnProgressChanged(ProgressBase progress)
+{
+    switch (progress)
+    {
+        case QueryGenerationProgress queryProgress:
+            Console.WriteLine($"Query generated: {queryProgress.Query}");
+            Console.WriteLine($"Query generation rationale: {queryProgress.Rationale}");
+            break;
+        case WebResearchProgress webProgress:
+            Console.WriteLine($"Web search completed: Retrieved {webProgress.Sources.Count} sources");
+            Console.WriteLine($"Web search completed: Retrieved {webProgress.Images.Count} images");
+            break;
+        case SummarizeProgress summarizeProgress:
+            Console.WriteLine($"Summary: {summarizeProgress.Summary}");
+            break;
+        case ReflectionProgress reflectionProgress:
+            Console.WriteLine("Reflection completed");
+            Console.WriteLine($"Knowledge gap: {reflectionProgress.KnowledgeGap}");
+            Console.WriteLine($"Additional search query: {reflectionProgress.Query}");
+            break;
+        case RoutingProgress routingProgress:
+            Console.WriteLine($"Route decision: {routingProgress.Decision}");
+            Console.WriteLine($"Loop iteration count: {routingProgress.LoopCount}");
+            break;
+        case FinalizeProgress finalizeProgress:
+            Console.WriteLine("Creating final report...");
+            break;
+        case ResearchCompleteProgress completeProgress:
+            Console.WriteLine("Research completed");
+            Console.WriteLine($"Final Summary: {completeProgress.FinalSummary}");
+            Console.WriteLine($"Reference information: {string.Join(", ", completeProgress.Sources)}");
+            Console.WriteLine($"Images: {string.Join(", ", completeProgress.Images)}");
+            break;
+        case ErrorProgress errorProgress:
+            Console.WriteLine($"An error occurred: {errorProgress.Message}");
+            break;
+        default:
+            Console.WriteLine("Unknown notification type");
+            break;
+    }
+}
 ```
 
 ## Sample Clients

--- a/README_ja.md
+++ b/README_ja.md
@@ -69,6 +69,11 @@ var ChatClient = new AzureOpenAIClient(
     new DefaultAzureCredential()
 ).GetChatClient("o4-mini");
 
+void OnProgressChanged(ProgressBase progress)
+{
+  // Handle progress updates here
+}
+
 var options = new DeepResearchOptions
 {
     MaxResearchLoops = 3, // 最大ループ数
@@ -87,10 +92,78 @@ var result = await service.RunResearchAsync(researchTopic, CancellationToken.Non
 Console.WriteLine("\n" + new string('=', 50));
 Console.WriteLine("📋 調査結果");
 Console.WriteLine(new string('=', 50));
-Console.WriteLine(result.RunningSummary);
+Console.WriteLine(result.Summary);
 
 Console.WriteLine("\nPress any key to exit...");
 Console.ReadKey();
+```
+
+## 戻り値と逐次通知
+
+DeepResearchService は、調査が完了した際に ResearchResult 型のオブジェクトを返します。
+このオブジェクトには、調査の要約や関連する情報が含まれています。
+
+- ResearchTopic : 調査対象のトピック
+- Summary : 調査の最終レポート
+- Sources : 調査中に収集された情報のリスト
+- Images : 調査中に収集された画像のリスト
+
+また、DeepResearchService のコンストラクタ引数で onProgressChanged コールバックを指定することで、調査の通知状況をリアルタイムで受け取ることができます。
+逐次通知は ProgressBase を継承した各ステップごとのクラスが定義されています。
+
+- QueryGenerationProgress: クエリ生成完了の通知クラス
+- WebResearchProgress: Web 検索完了の通知クラス
+- SummarizeProgress: 検索結果の要約完了の通知クラス
+- ReflectionProgress: 知識ギャップの補完完了の通知クラス
+- RoutingProgress: 次の処理の判定完了の通知クラス
+- FinalizeProgress: 調査レポートの作成開始の通知クラス
+- ResearchCompleteProgress: 調査レポートの作成完了の通知クラス
+- ErrorProgress: 調査中にエラーが発生した際の通知クラス
+
+例えば以下のように通知クラスを受けとってハンドルすることができます。
+
+```csharp
+void OnProgressChanged(ProgressBase progress)
+{
+    switch (progress)
+    {
+        case QueryGenerationProgress queryProgress:
+            Console.WriteLine($"クエリを生成: {queryProgress.Query}");
+            Console.WriteLine($"クエリ生成の理由: {queryProgress.Rationale}");
+            break;
+        case WebResearchProgress webProgress:
+            Console.WriteLine($"Web検索完了： {webProgress.Sources.Count} 件のソースを取得");
+            Console.WriteLine($"Web検索完了： {webProgress.Images.Count} 枚の画像を取得");
+            break;
+        case SummarizeProgress summarizeProgress:
+            Console.WriteLine($"要約: {summarizeProgress.Summary}");
+            break;
+        case ReflectionProgress reflectionProgress:
+            Console.WriteLine("リフレクション完了");
+            Console.WriteLine($"知識ギャップ: {reflectionProgress.KnowledgeGap}");
+            Console.WriteLine($"追加検索クエリ: {reflectionProgress.Query}");
+            break;
+        case RoutingProgress routingProgress:
+            Console.WriteLine($"ルートの決定 {routingProgress.Decision}");
+            Console.WriteLine($"ループ思考回数 {routingProgress.LoopCount}");
+            break;
+        case FinalizeProgress finalizeProgress:
+            Console.WriteLine("最終レポートの作成中.");
+            break;
+        case ResearchCompleteProgress completeProgress:
+            Console.WriteLine("調査の完了");
+            Console.WriteLine($"Final Summary: {completeProgress.FinalSummary}");
+            Console.WriteLine($"参考情報: {string.Join(", ", completeProgress.Sources)}");
+            Console.WriteLine($"画像: {string.Join(", ", completeProgress.Images)}");
+            break;
+        case ErrorProgress errorProgress:
+            Console.WriteLine($"エラーが発生しました。: {errorProgress.Message}");
+            break;
+        default:
+            Console.WriteLine("不明な通知型");
+            break;
+    }
+}
 ```
 
 ## サンプルクライアント

--- a/app/DeepResearch.Console/Program.cs
+++ b/app/DeepResearch.Console/Program.cs
@@ -99,7 +99,7 @@ var result = await service.RunResearchAsync(researchTopic, CancellationToken.Non
 Console.WriteLine("\n" + new string('=', 50));
 Console.WriteLine("📋 調査結果");
 Console.WriteLine(new string('=', 50));
-Console.WriteLine(result.RunningSummary);
+Console.WriteLine(result.Summary);
 
 Console.WriteLine("\nPress any key to exit...");
 Console.ReadKey();

--- a/app/DeepResearch.Core/Models/ResearchCompleteProgress.cs
+++ b/app/DeepResearch.Core/Models/ResearchCompleteProgress.cs
@@ -1,3 +1,5 @@
+using DeepResearch.SearchClient;
+
 namespace DeepResearch.Core.Models;
 
 public class ResearchCompleteProgress : ProgressBase
@@ -7,5 +9,6 @@ public class ResearchCompleteProgress : ProgressBase
     }
 
     public string? FinalSummary { get; set; }
+    public List<SearchResultItem> Sources { get; set; } = new();
     public List<string> Images { get; set; } = new();
 }

--- a/app/DeepResearch.Core/ResearchResult.cs
+++ b/app/DeepResearch.Core/ResearchResult.cs
@@ -1,0 +1,29 @@
+using DeepResearch.SearchClient;
+
+namespace DeepResearch.Core;
+
+/// <summary>
+/// Represents the final result of a research operation, containing only the information needed by clients.
+/// </summary>
+public class ResearchResult
+{
+    /// <summary>
+    /// The topic that was researched.
+    /// </summary>
+    public string ResearchTopic { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The final summary of the research findings.
+    /// </summary>
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The structured source information used in the research.
+    /// </summary>
+    public List<SearchResultItem> Sources { get; set; } = new();
+
+    /// <summary>
+    /// Images found during the research process.
+    /// </summary>
+    public List<string> Images { get; set; } = new();
+}

--- a/app/DeepResearch.Core/ResearchState.cs
+++ b/app/DeepResearch.Core/ResearchState.cs
@@ -1,14 +1,17 @@
+using DeepResearch.SearchClient;
+
 namespace DeepResearch.Core;
 
-using System.Collections.Generic;
-
-public class ResearchState
+/// <summary>
+/// Internal state used during the research process. Contains all intermediate data and processing state.
+/// </summary>
+internal class ResearchState
 {
     public string ResearchTopic { get; set; } = string.Empty;
     public string SearchQuery { get; set; } = string.Empty;
     public string RunningSummary { get; set; } = string.Empty;
     public int ResearchLoopCount { get; set; } = 0;
-    public List<string> SourcesGathered { get; set; } = new();
+    public List<SearchResultItem> SourcesGathered { get; set; } = new();
     public List<string> WebResearchResults { get; set; } = new();
     public List<string> Images { get; set; } = new();
     public string KnowledgeGap { get; set; } = string.Empty;

--- a/app/DeepResearch.Web/Components/Pages/Home.razor
+++ b/app/DeepResearch.Web/Components/Pages/Home.razor
@@ -49,7 +49,7 @@
     </header>
 
     <!-- Main Content -->
-    <main class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pt-24">
+    <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pt-24">
         <!-- Research Input Form -->
         <div class="bg-white rounded-lg shadow-lg p-6 mb-8">
             <h2 class="text-2xl font-bold text-gray-900 mb-4">調査トピックを入力してください</h2>
@@ -105,42 +105,47 @@
         }
 
         <!-- Final Research Report -->
-        @if (!string.IsNullOrEmpty(finalReport))
+        @if (researchResult != null)
         {
             <div class="bg-white rounded-lg shadow-lg p-6">
                 <h3 class="text-2xl font-semibold text-gray-900 mb-4">調査レポート</h3>
+                
+                <hr class="my-6 border-gray-200" />
 
+                <h4 class="text-lg font-semibold text-gray-900 mt-6 mb-2">調査トピック</h4>
+                <p class="text-gray-700 mb-4">@researchResult.ResearchTopic</p>
+
+                <hr class="my-6 border-gray-200" />
+
+                <h4 class="text-lg font-semibold text-gray-900 mt-6 mb-2">調査サマリー</h4>
                 <div class="prose max-w-none">
-                    @((MarkupString)(!string.IsNullOrEmpty(finalReport) ? Markdown.ToHtml(finalReport) : ""))
+                    @((MarkupString)(!string.IsNullOrEmpty(researchResult.Summary) ? Markdown.ToHtml(researchResult.Summary) : ""))
                 </div>
 
                 <hr class="my-6 border-gray-200" />
 
-                @if(sources.Any())
+                @if(researchResult.Sources.Any())
                 {
                     <h4 class="text-lg font-semibold text-gray-900 mt-6 mb-2">参考文献</h4>
                     <ul class="list-disc list-inside mb-6">
-                        @if (sources != null && sources.Any())
+                        @foreach (var source in researchResult.Sources)
                         {
-                            @foreach (var source in sources)
-                            {
-                                <li>
-                                    <a href="@source.Url" target="_blank" class="text-blue-600 hover:underline">
-                                        @source.Title
-                                    </a>
-                                </li>
-                            }
-                        }
+                            <li>
+                                <a href="@source.Url" target="_blank" class="text-blue-600 hover:underline">
+                                    @source.Title
+                                </a>
+                            </li>
+                        }   
                     </ul>
                 }
 
                 <!-- Images Section -->
-                @if (finalImages.Any())
+                @if (researchResult.Images.Any())
                 {
                     <div class="mb-6">
                         <h4 class="text-lg font-semibold text-gray-900 mb-2">関連画像</h4>
                         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                            @foreach (var image in finalImages)
+                            @foreach (var image in researchResult.Images)
                             {
                                 <div class="rounded-lg overflow-hidden shadow-md">
                                     <img src="@image" alt="Research Image" class="w-full h-auto object-cover" />
@@ -158,9 +163,7 @@
 @code {
     private string researchTopic = "";
     private bool isResearching = false;
-    private string finalReport = "";
-    private List<SearchResultItem> sources;
-    private List<string> finalImages = new();
+    private ResearchResult? researchResult = null;
 
 
     private async Task StartResearch()
@@ -169,7 +172,7 @@
         {
             _researchService.OnProgressUpdated += TriggerStateHasChanged;
             isResearching = true;
-            await _researchService.StartResearchAsync(researchTopic);            
+            researchResult = await _researchService.StartResearchAsync(researchTopic);            
         }
         catch (Exception ex)
         {
@@ -259,13 +262,6 @@
                 var researchCompleteProgress = DeserializeProgressData<ResearchCompleteProgress>(message);
                 if (researchCompleteProgress != null)
                 {
-                    if (!string.IsNullOrEmpty(researchCompleteProgress.FinalSummary))
-                    {
-                        finalReport = researchCompleteProgress.FinalSummary;
-                        sources = researchCompleteProgress.Sources;
-                    }
-                    finalImages.Clear();
-                    finalImages.AddRange(researchCompleteProgress.Images);
                     content = "<strong>調査が完了しました！</strong>";
                 }
                 break;

--- a/app/DeepResearch.Web/Components/Pages/Home.razor
+++ b/app/DeepResearch.Web/Components/Pages/Home.razor
@@ -2,6 +2,7 @@
 @using DeepResearch.Core
 @using DeepResearch.Core.Models
 @using System.Text.Json
+@using DeepResearch.SearchClient
 @using DeepResearch.Web.Services
 @using Markdig
 @inject IJSRuntime JSRuntime
@@ -109,35 +110,46 @@
             <div class="bg-white rounded-lg shadow-lg p-6">
                 <h3 class="text-2xl font-semibold text-gray-900 mb-4">調査レポート</h3>
 
+                <div class="prose max-w-none">
+                    @((MarkupString)(!string.IsNullOrEmpty(finalReport) ? Markdown.ToHtml(finalReport) : ""))
+                </div>
+
+                <hr class="my-6 border-gray-200" />
+
+                @if(sources.Any())
+                {
+                    <h4 class="text-lg font-semibold text-gray-900 mt-6 mb-2">参考文献</h4>
+                    <ul class="list-disc list-inside mb-6">
+                        @if (sources != null && sources.Any())
+                        {
+                            @foreach (var source in sources)
+                            {
+                                <li>
+                                    <a href="@source.Url" target="_blank" class="text-blue-600 hover:underline">
+                                        @source.Title
+                                    </a>
+                                </li>
+                            }
+                        }
+                    </ul>
+                }
+
                 <!-- Images Section -->
                 @if (finalImages.Any())
                 {
                     <div class="mb-6">
-                        @if (finalImages.Count >= 2)
-                        {
-                            <div class="flex flex-col md:flex-row gap-4 mb-6">
-                                <div class="w-full md:w-1/2">
-                                    <img src="@finalImages[0]" alt="Research image 1" class="w-full h-auto rounded-lg shadow-md" />
+                        <h4 class="text-lg font-semibold text-gray-900 mb-2">関連画像</h4>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                            @foreach (var image in finalImages)
+                            {
+                                <div class="rounded-lg overflow-hidden shadow-md">
+                                    <img src="@image" alt="Research Image" class="w-full h-auto object-cover" />
                                 </div>
-                                <div class="w-full md:w-1/2">
-                                    <img src="@finalImages[1]" alt="Research image 2" class="w-full h-auto rounded-lg shadow-md" />
-                                </div>
-                            </div>
-                        }
-                        else if (finalImages.Count == 1)
-                        {
-                            <div class="flex justify-center mb-6">
-                                <div class="w-full max-w-lg">
-                                    <img src="@finalImages[0]" alt="Research image" class="w-full h-auto rounded-lg shadow-md" />
-                                </div>
-                            </div>
-                        }
+                            }
+                        </div>
                     </div>
                 }
 
-                <div class="prose max-w-none">
-                    @((MarkupString)(!string.IsNullOrEmpty(finalReport) ? Markdown.ToHtml(finalReport) : ""))
-                </div>
             </div>
         }
     </main>
@@ -147,6 +159,7 @@
     private string researchTopic = "";
     private bool isResearching = false;
     private string finalReport = "";
+    private List<SearchResultItem> sources;
     private List<string> finalImages = new();
 
 
@@ -249,6 +262,7 @@
                     if (!string.IsNullOrEmpty(researchCompleteProgress.FinalSummary))
                     {
                         finalReport = researchCompleteProgress.FinalSummary;
+                        sources = researchCompleteProgress.Sources;
                     }
                     finalImages.Clear();
                     finalImages.AddRange(researchCompleteProgress.Images);

--- a/app/DeepResearch.Web/Services/WebResearchService.cs
+++ b/app/DeepResearch.Web/Services/WebResearchService.cs
@@ -25,7 +25,7 @@ public class WebResearchService
         _searchClient = searchClient;
     }
 
-    public async Task StartResearchAsync(string topic, CancellationToken cancellationToken = default)
+    public async Task<ResearchResult?> StartResearchAsync(string topic, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -33,19 +33,19 @@ public class WebResearchService
             if (_chatClient == null)
             {
                 NotifyClient(new ErrorProgress { Message = "Azure OpenAI設定が不完全です。" });
-                return;
+                return null;
             }
 
             if (_searchClient == null)
             {
                 NotifyClient(new ErrorProgress { Message = "Tavily API設定が不完全です。" });
-                return;
+                return null;
             }
 
             if (string.IsNullOrWhiteSpace(topic))
             {
                 NotifyClient(new ErrorProgress { Message = "トピックは必須です。" });
-                return;
+                return null;
             }
 
             NotifyClient(new ThinkingProgress { Message = "調査を開始します..." });
@@ -62,12 +62,13 @@ public class WebResearchService
                 reseachOption
             );
 
-            await researchService.RunResearchAsync(topic, cancellationToken);
+            return await researchService.RunResearchAsync(topic, cancellationToken);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "調査中にエラーが発生しました。トピック: {Topic}", topic);
             NotifyClient(new ErrorProgress { Message = $"エラーが発生しました: {ex.Message}" });
+            return null;
         }
     }
 


### PR DESCRIPTION
The type returned after a series of investigations is completed is ResearchState, but since ResearchState contains properties used internally during the investigation process and are unnecessary for the final response, it will be separated into a state class used internally and a result class that is ultimately returned to the client.

Fix #5 
