### PR TITLE
Add EnableSummaryConsolidation option and update related logic for fi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ var options = new DeepResearchOptions
 {
     MaxResearchLoops = 3, // Maximum number of loops
     MaxCharacterPerSource = 1000, // Maximum character count per source
-    MaxSourceCountPerSearch = 5 // Maximum number of sources per search
+    MaxSourceCountPerSearch = 5, // Maximum number of sources per search
+    EnableSummaryConsolidation = true // A flag indicating whether to integrate all step summaries into the final answer. If set to True, adjust the above three parameters with consideration for the context length limit.
 };
 
 Console.WriteLine("Deep Research Console");

--- a/README_ja.md
+++ b/README_ja.md
@@ -78,7 +78,8 @@ var options = new DeepResearchOptions
 {
     MaxResearchLoops = 3, // 最大ループ数
     MaxCharacterPerSource = 1000, // ソースごとの最大文字数
-    MaxSourceCountPerSearch = 5 // 検索ごとの最大ソース数
+    MaxSourceCountPerSearch = 5, // 検索ごとの最大ソース数
+    EnableSummaryConsolidation = true // 最終回答の生成にすべてのステップサマリーを統合するかどうかのフラグ。Trueにする場合はコンテキスト長の制限に注意して上の３つのパラメーターを調整する。
 };
 
 Console.WriteLine("Deep Research Console");

--- a/app/DeepResearch.Core/DeepResearchOptions.cs
+++ b/app/DeepResearch.Core/DeepResearchOptions.cs
@@ -20,4 +20,11 @@ public class DeepResearchOptions
     /// </summary>
     /// <example>5</example>
     public int MaxSourceCountPerSearch { get; set; } = 5;
+
+    /// <summary>
+    /// Flag to combine all the individual summaries to generate a final summary
+    /// </summary>
+    /// <example>true</example>
+    public bool EnableSummaryConsolidation { get; set; } = false;
+
 }

--- a/app/DeepResearch.Core/Prompts/FinalizeInstructions.cs
+++ b/app/DeepResearch.Core/Prompts/FinalizeInstructions.cs
@@ -1,0 +1,22 @@
+﻿namespace DeepResearch.Core;
+
+internal static partial class Prompts
+{
+    internal static string FinalizeInstructions(List<string> summariesGathered)
+    {
+        return
+        $"""
+        - Your task is to synthesize the piecemeal researched summaries to create a coherent final report.
+        - Your goal is to create a final report on the <TOPIC> submitted by the user with the information in the <SUMMARIES>.
+        - Do not use any knowledge other than the provided <SUMMARIES>.
+        - You will be provided with a list of summaries created during the research process.
+        - Use the provided summaries to create a comprehensive final report.
+        - Make sure your final report is clear and concise and captures the essence of the research conducted.
+        - Generate your final report in the same language used in the <TOPIC>.
+
+        <SUMMARIES>
+        {summariesGathered.Select(s => $"<SUMMARY>{s}</SUMMARY>").Aggregate((a, b) => $"{a}\n{b}")}
+        </SUMMARIES>
+        """;
+    }
+}

--- a/app/DeepResearch.Core/ResearchState.cs
+++ b/app/DeepResearch.Core/ResearchState.cs
@@ -16,4 +16,5 @@ internal class ResearchState
     public List<string> Images { get; set; } = new();
     public string KnowledgeGap { get; set; } = string.Empty;
     public string QueryRationale { get; set; } = string.Empty;
+    public List<string> SummariesGathered { get; set; } = new();
 }

--- a/app/DeepResearch.Web/Components/Pages/Home.razor
+++ b/app/DeepResearch.Web/Components/Pages/Home.razor
@@ -49,7 +49,7 @@
     </header>
 
     <!-- Main Content -->
-    <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pt-24">
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 pt-24">
         <!-- Research Input Form -->
         <div class="bg-white rounded-lg shadow-lg p-6 mb-8">
             <h2 class="text-2xl font-bold text-gray-900 mb-4">調査トピックを入力してください</h2>


### PR DESCRIPTION
This pull request introduces a new feature to enable summary consolidation during the research process, along with supporting changes across the codebase. It also includes minor UI adjustments and updates to documentation. The most important changes are grouped by theme below.

### Feature: Summary Consolidation

* Added a new property `EnableSummaryConsolidation` to the `DeepResearchOptions` class to allow combining individual summaries into a final coherent report.
* Updated the `DeepResearchService` to use the `EnableSummaryConsolidation` flag for generating a final summary, incorporating all gathered summaries.
* Introduced a new method `FinalizeInstructions` in `Prompts` to synthesize multiple summaries into a final report.
* Modified `ResearchState` to include a new `SummariesGathered` property for storing intermediate summaries.

### Code Refactoring

* Replaced individual research-related configuration fields in `DeepResearchService` with a single `DeepResearchOptions` object for cleaner code and easier parameter management. [[1]](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fL13-R13) [[2]](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fL45-R42) [[3]](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fL56-R51) [[4]](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fL123-R126)

### Documentation Updates

* Updated `README.md` and `README_ja.md` to document the new `EnableSummaryConsolidation` flag and its implications. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R82) [[2]](diffhunk://#diff-f352f176b719ca7e5c1025e2c75daa964dc961db4de4768a58a4b84fbee095b0L81-R82)

### UI Adjustment

* Increased the maximum width of the main content area on the homepage from `max-w-6xl` to `max-w-7xl` for better visual presentation.

fix #2 