### PR TITLE
Implementation of search retry logic

### DIFF
--- a/app/DeepResearch.Console/Program.cs
+++ b/app/DeepResearch.Console/Program.cs
@@ -77,7 +77,7 @@ void OnProgressChanged(ProgressBase progress)
                 _ => $"<strong>次の処理を判断:</strong> {decisionText} (ループ {routingProgress.LoopCount + 1})"
             };
 
-            Console.WriteLine($"[{timestamp}] 🔄 次のステップを決定中: {content})");
+            Console.WriteLine($"[{timestamp}] 🔄 次のステップを決定中: {content}");
 
             break;
 

--- a/app/DeepResearch.Console/Program.cs
+++ b/app/DeepResearch.Console/Program.cs
@@ -67,9 +67,18 @@ void OnProgressChanged(ProgressBase progress)
             {
                 RoutingDecision.Continue => "調査を続行",
                 RoutingDecision.Finalize => "調査を完了",
+                RoutingDecision.RetrySearch => "再検索",
                 _ => routingProgress.Decision.ToString()
             };
-            Console.WriteLine($"[{timestamp}] 🔄 次のステップを決定中: {decisionText} (ループ {routingProgress.LoopCount + 1})");
+
+            var content = routingProgress.Decision switch
+            {
+                RoutingDecision.RetrySearch => $"<strong>次の処理を判断:</strong> {decisionText} (リトライ回数：{routingProgress.LoopCount + 1})",
+                _ => $"<strong>次の処理を判断:</strong> {decisionText} (ループ {routingProgress.LoopCount + 1})"
+            };
+
+            Console.WriteLine($"[{timestamp}] 🔄 次のステップを決定中: {content})");
+
             break;
 
         case FinalizeProgress finalizeProgress:

--- a/app/DeepResearch.Core/DeepResearchOptions.cs
+++ b/app/DeepResearch.Core/DeepResearchOptions.cs
@@ -27,4 +27,9 @@ public class DeepResearchOptions
     /// <example>true</example>
     public bool EnableSummaryConsolidation { get; set; } = false;
 
+    /// <summary>
+    /// Maximum number of query regeneration attempts when search returns no results.
+    /// </summary>
+    /// <example>3</example>
+    public int MaxSearchRetryAttempts { get; set; } = 3;
 }

--- a/app/DeepResearch.Core/DeepResearchService.cs
+++ b/app/DeepResearch.Core/DeepResearchService.cs
@@ -86,20 +86,31 @@ public class DeepResearchService
         };
     }
 
-    private async Task GenerateQueryAsync(ResearchState state, CancellationToken cancellationToken = default)
+    private async Task GenerateQueryAsync(ResearchState state, CancellationToken cancellationToken = default, bool isRetry = false)
     {
         var prompt = string.Format(Prompts.QueryWriterInstructions, DateTime.Now.ToString("MMMM dd, yyyy"), state.ResearchTopic);
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(prompt),
-            new UserChatMessage("Generate a query for web search:")
-        };
 
-        var result = await _aiChatClient.CompleteChatAsync(messages, _generateQueryOptions);
-        if (result.Value.FinishReason != ChatFinishReason.Stop) throw new InvalidOperationException($"AI chat completion failed withz finish reason: {result.Value.FinishReason}");
+        if (isRetry && state.QueryGenerationMessages.Count > 0)
+        {
+            // Add retry message to existing conversation
+            state.QueryGenerationMessages.Add(new UserChatMessage("The previous query returned no results. Please generate a different search query."));
+        }
+        else
+        {
+            // Start new conversation
+            state.QueryGenerationMessages.Clear();
+            state.QueryGenerationMessages.Add(new SystemChatMessage(prompt));
+            state.QueryGenerationMessages.Add(new UserChatMessage("Generate a query for web search:"));
+        }
+
+        var result = await _aiChatClient.CompleteChatAsync(state.QueryGenerationMessages, _generateQueryOptions);
+        if (result.Value.FinishReason != ChatFinishReason.Stop) throw new InvalidOperationException($"AI chat completion failed with finish reason: {result.Value.FinishReason}");
 
         var generateQueryResponse = JsonSerializer.Deserialize<GenerateQueryResponse>(result.Value.Content.First().Text, _jsonSerializerOptions);
         if (generateQueryResponse == null) throw new InvalidOperationException("Failed to deserialize GenerateQueryResponse");
+
+        // Add assistant response to conversation history
+        state.QueryGenerationMessages.Add(new AssistantChatMessage(result.Value.Content.First().Text));
 
         state.SearchQuery = generateQueryResponse.Query;
         state.QueryRationale = generateQueryResponse.Rationale;
@@ -117,17 +128,44 @@ public class DeepResearchService
             query: state.SearchQuery,
             maxResults: _researchOptions.MaxSourceCountPerSearch,
             cancellationToken: cancellationToken);
+
+        // Check if no results and retry limit not exceeded
+        if ((searchResult.Results == null || searchResult.Results.Count == 0) &&
+            state.QueryRetryCount < _researchOptions.MaxSearchRetryAttempts)
+        {
+            state.QueryRetryCount++;
+
+            // Decide whether to use GenerateQueryAsync or ReflectOnSummaryAsync
+            if (string.IsNullOrEmpty(state.RunningSummary))
+            {
+                // No summary yet, regenerate initial query with retry message
+                await GenerateQueryAsync(state, cancellationToken, isRetry: true);
+            }
+            else
+            {
+                // Have summary, use reflection to generate new query with retry message
+                await ReflectOnSummaryAsync(state, cancellationToken, isRetry: true);
+            }
+
+            // Recursively call WebResearchAsync with new query
+            await WebResearchAsync(state, cancellationToken);
+            return;
+        }
+
+        // Reset retry count on successful search or when max retries exceeded
+        state.QueryRetryCount = 0;
+
         state.Images.AddRange(searchResult.Images ?? new List<string>());
 
         // Add deduplicated and cleaned sources to SourcesGathered
-        var newSources = Formatting.DeduplicateAndCleanSources(searchResult.Results, state.SourcesGathered);
+        var newSources = Formatting.DeduplicateAndCleanSources(searchResult.Results ?? new List<SearchResultItem>(), state.SourcesGathered);
         state.SourcesGathered.AddRange(newSources);
 
         state.WebResearchResults.Add(Formatting.DeduplicateAndFormatSources(searchResult, _researchOptions.MaxCharacterPerSource));
 
         NotifyProgress(new WebResearchProgress
         {
-            Sources = searchResult.Results,
+            Sources = searchResult.Results ?? new List<SearchResultItem>(),
             Images = searchResult.Images ?? new List<string>()
         });
     }
@@ -159,20 +197,32 @@ public class DeepResearchService
         });
     }
 
-    private async Task ReflectOnSummaryAsync(ResearchState state, CancellationToken cancellationToken = default)
+    private async Task ReflectOnSummaryAsync(ResearchState state, CancellationToken cancellationToken = default, bool isRetry = false)
     {
         var prompt = string.Format(Prompts.ReflectionInstructions, state.ResearchTopic);
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(prompt),
-            new UserChatMessage($"Reflect on our existing knowledge: \n===\n{state.RunningSummary},\n===\nAnd now identify a knowledge gap and generate a follow-up web search query:")
-        };
+        var baseMessage = $"Reflect on our existing knowledge: \n===\n{state.RunningSummary},\n===\nAnd now identify a knowledge gap and generate a follow-up web search query:";
 
-        var result = await _aiChatClient.CompleteChatAsync(messages, _reflectionOnSummaryOptions);
+        if (isRetry && state.ReflectionMessages.Count > 0)
+        {
+            // Add retry message to existing conversation
+            state.ReflectionMessages.Add(new UserChatMessage("The previous query returned no results. Please generate a different search query."));
+        }
+        else
+        {
+            // Start new conversation
+            state.ReflectionMessages.Clear();
+            state.ReflectionMessages.Add(new SystemChatMessage(prompt));
+            state.ReflectionMessages.Add(new UserChatMessage(baseMessage));
+        }
+
+        var result = await _aiChatClient.CompleteChatAsync(state.ReflectionMessages, _reflectionOnSummaryOptions);
         if (result.Value.FinishReason != ChatFinishReason.Stop) throw new InvalidOperationException($"AI chat completion failed with finish reason: {result.Value.FinishReason}");
 
         var reflectionResponse = JsonSerializer.Deserialize<ReflectionOnSummaryResponse>(result.Value.Content.First().Text, _jsonSerializerOptions);
         if (reflectionResponse == null) throw new InvalidOperationException("Failed to deserialize ReflectionOnSummaryResponse");
+
+        // Add assistant response to conversation history
+        state.ReflectionMessages.Add(new AssistantChatMessage(result.Value.Content.First().Text));
 
         state.SearchQuery = reflectionResponse.FollowUpQuery;
         state.KnowledgeGap = reflectionResponse.KnowledgeGap;

--- a/app/DeepResearch.Core/DeepResearchService.cs
+++ b/app/DeepResearch.Core/DeepResearchService.cs
@@ -135,6 +135,12 @@ public class DeepResearchService
         {
             state.QueryRetryCount++;
 
+            NotifyProgress(new RoutingProgress
+            {
+                Decision = RoutingDecision.RetrySearch,
+                LoopCount = state.QueryRetryCount
+            });
+
             // Decide whether to use GenerateQueryAsync or ReflectOnSummaryAsync
             if (string.IsNullOrEmpty(state.RunningSummary))
             {

--- a/app/DeepResearch.Core/DeepResearchService.cs
+++ b/app/DeepResearch.Core/DeepResearchService.cs
@@ -132,13 +132,13 @@ public class DeepResearchService
         if ((searchResult.Results == null || searchResult.Results.Count == 0) &&
             state.QueryRetryCount < _researchOptions.MaxSearchRetryAttempts)
         {
-            state.QueryRetryCount++;
-
             NotifyProgress(new RoutingProgress
             {
                 Decision = RoutingDecision.RetrySearch,
                 LoopCount = state.QueryRetryCount
             });
+
+            state.QueryRetryCount++;
 
             // Decide whether to use GenerateQueryAsync or ReflectOnSummaryAsync
             if (string.IsNullOrEmpty(state.RunningSummary))

--- a/app/DeepResearch.Core/Models/RoutingProgress.cs
+++ b/app/DeepResearch.Core/Models/RoutingProgress.cs
@@ -13,5 +13,6 @@ public class RoutingProgress : ProgressBase
 public enum RoutingDecision
 {
     Continue,
+    RetrySearch,
     Finalize
 }

--- a/app/DeepResearch.Core/ResearchState.cs
+++ b/app/DeepResearch.Core/ResearchState.cs
@@ -1,4 +1,5 @@
 using DeepResearch.SearchClient;
+using OpenAI.Chat;
 
 namespace DeepResearch.Core;
 
@@ -17,4 +18,7 @@ internal class ResearchState
     public string KnowledgeGap { get; set; } = string.Empty;
     public string QueryRationale { get; set; } = string.Empty;
     public List<string> SummariesGathered { get; set; } = new();
+    public int QueryRetryCount { get; set; } = 0;
+    public List<ChatMessage> QueryGenerationMessages { get; set; } = new();
+    public List<ChatMessage> ReflectionMessages { get; set; } = new();
 }

--- a/app/DeepResearch.Web/Components/Pages/Home.razor
+++ b/app/DeepResearch.Web/Components/Pages/Home.razor
@@ -214,9 +214,15 @@
                     {
                         RoutingDecision.Continue => "調査を続行",
                         RoutingDecision.Finalize => "調査を完了",
+                        RoutingDecision.RetrySearch => "再検索",
                         _ => routingProgress.Decision.ToString()
                     };
-                    content = $"<strong>次の処理を判断:</strong> {decisionText} (ループ {routingProgress.LoopCount + 1})";
+
+                    content = routingProgress.Decision switch
+                    {
+                        RoutingDecision.RetrySearch => $"<strong>次の処理を判断:</strong> {decisionText} (リトライ回数：{routingProgress.LoopCount + 1})",
+                        _ => $"<strong>次の処理を判断:</strong> {decisionText} (ループ {routingProgress.LoopCount + 1})"
+                    };
                 }
                 break;
                 


### PR DESCRIPTION
This pull request introduces a retry mechanism for web research queries when no results are returned, along with supporting updates to the codebase. The changes include enhancements to query generation and reflection processes, the addition of retry-specific logic, and updates to the user interface to reflect retry attempts.

### Retry Mechanism Enhancements

* **Addition of Retry Logic in Web Research**: Introduced a mechanism in `WebResearchAsync` to handle cases where no results are returned. The system retries query generation or reflection based on the presence of a summary, with a limit defined by the new `MaxSearchRetryAttempts` configuration. Retry count is reset upon success or reaching the maximum limit. (`app/DeepResearch.Core/DeepResearchService.cs`, [app/DeepResearch.Core/DeepResearchService.csR130-R173](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fR130-R173))

* **Updates to Query and Reflection Processes**: Modified `GenerateQueryAsync` and `ReflectOnSummaryAsync` to support retry scenarios. Added logic to manage conversation history and append retry-specific messages for better context during query regeneration. (`app/DeepResearch.Core/DeepResearchService.cs`, [[1]](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fL88-R113) [[2]](diffhunk://#diff-308d9234693ddcfb8217de57b41cf4d1b0ea0dd50b754964729bd90d03709b7fL161-R231)

### Configuration Updates

* **New Configuration Option**: Added the `MaxSearchRetryAttempts` property to `DeepResearchOptions` to define the maximum number of retry attempts for query regeneration. (`app/DeepResearch.Core/DeepResearchOptions.cs`, [app/DeepResearch.Core/DeepResearchOptions.csR30-R34](diffhunk://#diff-98c0a80c72fd7f31ce57470499c3f76a09814f5af5a589cebe7b918ca5e613aaR30-R34))

### Data Model Changes

* **Research State Enhancements**: Extended the `ResearchState` class to include `QueryRetryCount`, `QueryGenerationMessages`, and `ReflectionMessages` for tracking retries and managing conversation history. (`app/DeepResearch.Core/ResearchState.cs`, [app/DeepResearch.Core/ResearchState.csR21-R23](diffhunk://#diff-72a9db2328f47b1cd5186f2311d48b8b80b6bdf77c04c655a03216b4bb4173ecR21-R23))

* **Routing Decision Update**: Added a new `RoutingDecision.RetrySearch` enum value to represent retry attempts in the routing logic. (`app/DeepResearch.Core/Models/RoutingProgress.cs`, [app/DeepResearch.Core/Models/RoutingProgress.csR16](diffhunk://#diff-a40e533dc73bb44a42a03125dc65dfdf419f2d8186599a5c898e0dc48005fd40R16))

### UI Updates

* **Retry Information in Console and Web UI**: Updated progress reporting in `OnProgressChanged` and `Home.razor` to display retry count when `RoutingDecision.RetrySearch` is triggered. This ensures users are informed about retry attempts during research. (`app/DeepResearch.Console/Program.cs`, [[1]](diffhunk://#diff-7869e2c82fb9405254ce85fcc6f1d0714c784a0f6b748e114688713872eed910R70-R81); `app/DeepResearch.Web/Components/Pages/Home.razor`, [[2]](diffhunk://#diff-bdceb563966062073226a993ae93e23468f652d83848a0a53d611d74e456c9b1R217-R225)
Fix #7 